### PR TITLE
[Front] VictoryTooltip warning 해결 / [Back] 타입 value 대문자에서 소문자로 수정

### DIFF
--- a/client/src/components/chart/GenderResponseRate.tsx
+++ b/client/src/components/chart/GenderResponseRate.tsx
@@ -135,6 +135,7 @@ function GenderResponseRate({ statData }: { statData: subData }) {
           data={femaleResponseRate}
           labelComponent={
             <VictoryTooltip
+              renderInPortal={false}
               center={{ x: 150, y: 165 }}
               orientation="top"
               pointerLength={0}
@@ -160,6 +161,7 @@ function GenderResponseRate({ statData }: { statData: subData }) {
           endAngle={380}
           labelComponent={
             <VictoryTooltip
+              renderInPortal={false}
               center={{ x: 150, y: 165 }}
               orientation="top"
               pointerLength={0}

--- a/client/src/components/chart/OverallResponseRate.tsx
+++ b/client/src/components/chart/OverallResponseRate.tsx
@@ -81,6 +81,7 @@ function OverallResponseRate({ statData }: { statData: statData }) {
           data={overallResponse}
           labelComponent={
             <VictoryTooltip
+              renderInPortal={false}
               center={{ x: 150, y: 160 }}
               orientation="top"
               pointerLength={0}

--- a/server/src/schema/static.schema.ts
+++ b/server/src/schema/static.schema.ts
@@ -19,14 +19,14 @@ export class Static extends Document {
     default: '',
   })
   @IsString()
-  mapName: String;
+  mapName: string;
 
   @Prop({
     required: true,
     default: '',
   })
   @IsString()
-  regionName: String;
+  regionName: string;
 
   @Prop({
     required: true,


### PR DESCRIPTION
[Front]
* VictoryTooltip : renderInPortal={false} 추가하여 warning 해결

[Back]
* static schema: 타입 value 수정(대문자 -> 소문자)